### PR TITLE
Ignore /_uploads #1

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ app1 & MyNewTAG
 - Currently assume that it's okay that I have missed updates in the repos
   - At startup create a status of the current env and save in the DB.
   - From there start creating webhooks depending on new changes to the repos
+- Any tag called _uploads will be ignored by promotionChecker (this is a artifactory tmp folder)
 
 ## TODO
 

--- a/main.go
+++ b/main.go
@@ -72,6 +72,8 @@ func initZapLog() *zap.Logger {
 	return logger
 }
 
+const ignoreTag = "/_uploads"
+
 func main() {
 	loggerMgr := initZapLog()
 	zap.ReplaceGlobals(loggerMgr)
@@ -198,7 +200,8 @@ func runner(ctx context.Context, item *Items, client *http.Client, hmemdbRepo pr
 					}
 
 					// Returns true if a we have gotten a new tag
-					if promoter.StringNotInSlice(realTag, existingTags) {
+					//  and the new tag doesn't contain /_uploads
+					if realTag != ignoreTag && promoter.StringNotInSlice(realTag, existingTags) {
 						zap.S().Infof("Got a new tag in the image: %s ,repo: %s, newTag %v", image, repo, realTag)
 
 						// Post to the webhook endpoint

--- a/testServer/main.go
+++ b/testServer/main.go
@@ -36,6 +36,7 @@ func main() {
 	http.HandleFunc("/api/storage/repo1/app1", tags)
 	http.HandleFunc("/api/storage/repo2/app2", tags2)
 	http.HandleFunc("/update", update)
+	http.HandleFunc("/uploads", updateUploads)
 	http.HandleFunc("/webhook", webhook)
 	http.ListenAndServe(":8081", nil)
 }
@@ -84,6 +85,35 @@ func postTags() {
 		{URI: "/MyNewTAG", Folder: true},
 	}
 	fmt.Println("I have now updated Mylist")
+
+}
+
+func updateUploads(w http.ResponseWriter, r *http.Request) {
+	// Don't care what comes in I just return ok and see what request we got.
+	fmt.Println("We are inside the /updateUploads")
+
+	postTagsUploads()
+	bodyBytes, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		log.Fatal(err)
+	}
+	bodyString := string(bodyBytes)
+	fmt.Println(bodyString)
+
+	// Return a ok in normal text
+	js := []byte("ok")
+	w.Header().Set("Content-Type", "application/json")
+	w.Write(js)
+}
+
+func postTagsUploads() {
+	Mylist = []Children{
+		{URI: "/_uploads", Folder: true},
+		{URI: "/1.0.1-SNAPSHOT", Folder: true},
+		{URI: "/884b988", Folder: true},
+		{URI: "/MyNewTAG", Folder: true},
+	}
+	fmt.Println("I have now updated Mylist with /_uploads")
 
 }
 


### PR DESCRIPTION
* Artifactory seems to temporarley create a tag when you are promoting
  a new container to a repo.
  Don't want to trigger any webhooks on this folder.
* Update README with the assumptions that we don't support _uploads tags
* Update the testServer to easily be able to test this